### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG GO_VERSION='1.15'
+ARG ALPINE_VERSION='3.13'
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as build
+WORKDIR /build
+ENV CGO_ENABLED=0
+ENV GO111MODULE=on
+ENV GOBIN=/bin
+COPY . .
+RUN ls -a
+RUN go build -o /bin/terra-disk-manager ./...
+
+FROM alpine:${ALPINE_VERSION} as runtime
+COPY --from=build /bin/terra-disk-manager /bin/terra-disk-manager
+ENTRYPOINT [ "/bin/terra-disk-manager" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 ENV GOBIN=/bin
 COPY . .
-RUN ls -a
 RUN go build -o /bin/terra-disk-manager ./...
 
 FROM alpine:${ALPINE_VERSION} as runtime


### PR DESCRIPTION
Adds a basic go docker file which performs a 2 stage build in order to produce
a very small final image

﻿- Add basic go 2-stage dockerfile
- remove uneeded cmd
